### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ ul.toc {
 <div class="content">
 
 <div class="heading">
-<h1>Third International Workshop on Capturing Scientific Knowledge</h1>
+<h1>Third International Workshop on Capturing Scientific Knowledge (Sciknow 2019)</h1>
 
 <div class="subheading">
 November 19th, 2019<br>
@@ -88,6 +88,7 @@ Collocated with the tenth International Conference on Knowledge Capture (K-CAP)<
 <h2>Contents</h2>
 <ul class="toc">
 <!--<li><a href="#report">Workshop Report</a></li>-->
+<li><a href="#past_versions">Previous editions</a></li>
 <li><a href="#goals">Workshop Goals</a></li>
 <!--<li><a href="#gallery">Workshop Gallery</a></li>
 <li><a href="#schedule">Schedule</a></li>-->
@@ -97,42 +98,44 @@ Collocated with the tenth International Conference on Knowledge Capture (K-CAP)<
 <li><a href="#prog_committee">Program Committee</a></li>
 <!--<li><a href="#papers">Accepted Papers</a></li>-->
 </ul>
-<div id="report">
+<!--<div id="report">
 <h2>Workshop Report</h2>
 <p>A workshop report summarizing the contents and discussion of the workshop can be <a href="papers/report.pdf">found oline</a>. The organizers would like to thank all the participants for making SciKnow 2017 a great success.
 </p>
+</div>-->
+<div id="past_versions">
+<h2>Previous editions of Sciknow</h2>
+<ul>
+<li><a href="https://www.isi.edu/ikcap/sciknow2015/">Sciknow 2015</a> 
+<li><a href="https://sciknow.github.io/sciknow2017/">Sciknow 2017</a> 
+<ul>
+      <li><a href="https://sciknow.github.io/sciknow2017/papers/report.pdf"> Workshop report (2017)</a> </li>
+    </ul>
+</ul>
 </div>
+
 <div id="goals">
 <h2>Workshop Goals</h2>
-<p>The aim of SciKnow 2017 is to bring together researchers interested in representing and
-capturing knowledge about science so that it can be used by intelligent systems to support
-scientific research and discovery. 
+<p>The aim of SciKnow 2019 is to bring together researchers interested in representing and capturing knowledge about science 
+so that it can be used by intelligent systems to support scientific research and discovery.  
 </p>
-<p>From the early days of Artificial Intelligence, researchers have been interested in capturing
-scientific knowledge to develop intelligent systems. There are a variety of formalisms used
-today in different areas of science. Ontologies are widely used for organizing knowledge,
-particularly in biology and medicine. Process representations are used to do qualitative
-reasoning in areas such as physics and chemistry. Probabilistic graphical models are used
-by machine learning researchers, e.g., in climate modeling.</p>
+<p>From the early days of Artificial Intelligence, researchers have been interested in capturing 
+scientific knowledge to develop intelligent systems. A variety of formalisms are used today in 
+different areas of science.  Ontologies are widely used for organizing knowledge, particularly 
+in biology and medicine. Process representations are used to do qualitative reasoning in areas 
+such as physics and chemistry. Probabilistic graphical models are used by machine learning researchers, 
+e.g., in climate modeling. Recent work has looked at subsymbolic models for capturing scientific models 
+from the literature.</p>
 
-<p>In addition to enabling more advanced capabilities for intelligent systems in science,
-capturing scientific knowledge enables knowledge dissemination and open science
-practices. This is increasingly more important to enable the reuse of scientific knowledge
-across scientific disciplines, businesses and the public.
+<p>In addition to enabling more advanced capabilities for intelligent systems in science, capturing 
+scientific knowledge facilitates knowledge dissemination and open science practices.  This is increasingly 
+important to enable reusing scientific knowledge across scientific disciplines, businesses and the public.
 </p>
 
-<p>Although great advances have been made, scientific knowledge is complex and poses great
-challenges for knowledge capture. This workshop will provide a forum to discuss existing
-forms of scientific knowledge representation and existing systems that use them, and to
-envision major areas to augment and expand this important field of research.</p>
-
-<p>The increasing emphasis in open science has had a major focus on data sharing but it
-needs to encompass knowledge as well. There are many research challenges in open
-sharing and reuse of scientific knowledge that need to be addressed in future research.</p>
-
-<p>SciKnow2017 is the second version of a series,
-which started at K-CAP 2015 with a full day event (<a href="https://www.isi.edu/ikcap/sciknow2015/">https://www.isi.edu/ikcap/sciknow2015/)</a>.
-</p>
+<p>Despite recent advances, scientific knowledge is complex and poses significant challenges for knowledge capture.  
+This workshop will provide a forum to discuss, envision and expand existing forms of scientific knowledge representation 
+and dissemination; and existing systems that use them. There are many research challenges in open sharing 
+and reuse of scientific knowledge that need to be addressed in future research.</p>
 
 </div>
 <!--
@@ -228,6 +231,8 @@ Plenary discussion
 <h2>Submissions</h2>
 
 <p>Major topics of interest for this workshop include:</p>
+
+<mark>Should we encourage submissions of papers that discuss capturing and representing scientific knowledge derived from new forms of data such as crowdsourcing, IoT, and social media? </mark>
  
 <ul>
 <li>Capture of scientific knowledge:
@@ -257,10 +262,10 @@ Plenary discussion
 	<li>Challenge papers: Specific scenarios that describe the benefits to science if the limitations identified are overcome.</li>
 </ul>
 
-Submissions should be up to 6 pages and in the format of the ACM SIG Proceedings template: <a href="http://www.acm.org/sigs/publications/proceedings-templates">http://www.acm.org/sigs/publications/proceedings-templates</a>. However, <strong>SciKnow 2017 explicitly welcomes alternative and enhanced submission formats</strong>, such as HTML submissions. Authors who are preparing such a submission should contact the workshop organizers in advance to make sure we can accommodate for them in the submission and review process.
-Submissions should be emailed to sciknow2017@gmail.com.
+Submissions should be up to 6 pages including references and in the format of the Standard ACM SIG Conference Proceedings template: <a href="https://www.acm.org/publications/proceedings-template">https://www.acm.org/publications/proceedings-template</a>. However, <strong>SciKnow 2019 explicitly welcomes alternative and enhanced submission formats</strong>, such as HTML submissions. Authors who are preparing such a submission should contact the workshop organizers in advance to make sure we can accommodate for them in the submission and review process.
+<mark>Submissions should be emailed to sciknow2017@gmail.com. At least one author of each accepted paper is expected to attend the workshop.</mark>
  
-<p>Accepted papers will be made available on the workshop site.</p>
+<p><mark>Accepted papers will be published with the CEUR Workshop Proceedings (<a href="http://ceur-ws.org">CEUR-WS.org</a>), listed by the DBLP.</mark></p>
 
 
 </div>
@@ -268,9 +273,9 @@ Submissions should be emailed to sciknow2017@gmail.com.
 <div id="dates">
 </p><h2>Important Dates</h2> 
 <ul>
-<li>Submission deadline: <del>September 24th</del> October 7th, 2017
-</li><li>Notifications to authors: October 14th, 2017
-</li><li>Workshop: December 4, 2017
+<li>Submission deadline: TBD
+</li><li>Notifications to authors: TBD
+</li><li>Workshop: November 19, 2019
 </li></ul>
 </div>
 
@@ -278,26 +283,30 @@ Submissions should be emailed to sciknow2017@gmail.com.
 <h2>Organizing Committee</h2>
 <ul>
 <li>Daniel Garijo, University of Southern California</li>
-<li>Martine de Vos, Netherlands eScience Center</li>
+<li>Milan Markovic, University of Aberdeen</li>
+<li>Paul Groth, University of Amsterdam</li>
+<li>Idafen Santana, Universidad Politecnica de Madrid</li>
+<li>Khalid Belhajjame, University Paris-Dauphine</li>
+
 </ul>
 </div>
 
 <div id="prog_committee">
 <h2>Program Committee</h2>
 <ul>
-<li>Yolanda Gil, University of Southern California</li>
-<li>Tim Clark, Harvard University</li>
 <li>Derek Sleeman, University of Aberdeen</li>
+<li>Yolanda Gil, Information Sciences Institute, University of Southern California</li>
 <li>Idafen Santana, Universidad Politecnica de Madrid</li>
+<li>Oscar Corcho, Universidad Politecnica de Madrid</li>
 <li>Olga Ximena Giraldo, Universidad Politecnica de Madrid</li>
-<li>Alexander Garcia Castro, Universidad Politecnica de Madrid</li>
-<li>Gully Burns, University of Southern California</li>
-<li>Tobias Kuhn, VU University Amsterdam</li>
-<li>Paul Groth, Elsevier Labs</li>
+<li>Paul Groth, University of Amsterdam</li>
 <li>Silvio Peroni, University of Bologna</li>
-<li>Willem van Hage, Netherlands eScience center</li>
-<li>Jan Top, VU University Amsterdam</li>
-<li>Richard Boyce, University of Pittsburgh
+<li>Khalid Belhajjame, University Paris-Dauphine</li>
+<li>Anita de Waard, Elsevier</li>
+<li>Marieke van Erp,KNAW Humanities Cluster</li>
+<li>Amrapali Zaveri,Maastricht University</li>
+<li>Milan Markovic, University of Aberdeen</li>
+<li>Martine de Vos, Utrecht University</li>
 </ul>
 </div>
 


### PR DESCRIPTION
- added previous editions of Sciknow section
- updated workshop abstract according to google docs
- further proposed additions/things that need checking are highlighted 
- fixed the old ACM link to templates
- added Sciknow 2019 acronym to the title
- updated PC and OC members in the same order as listed on google docs
- the text with gmail address will need to change if we go for EasyChair or we need to register new gmail sciknow2019@gmail.com